### PR TITLE
feat: Add common and ssh_hardening roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+## Agent Instructions for Ansible Lab Management Repository
+
+Welcome, AI Agent! This document provides guidelines for working on this repository, which focuses on creating Ansible scripts for managing Linux lab VMs (Rocky Linux, Ubuntu, AlmaLinux).
+
+### Core Principles:
+
+1.  **Idempotency:** All Ansible tasks, playbooks, and roles must be idempotent. Running them multiple times should result in the same system state without errors.
+2.  **Modularity:** Favor roles for organizing reusable sets of tasks, variables, and handlers. Playbooks should primarily orchestrate these roles.
+3.  **Clarity and Readability:**
+    *   Use descriptive names for variables, tasks, roles, and playbooks.
+    *   Comment complex tasks or non-obvious logic.
+    *   Structure YAML files consistently with proper indentation.
+4.  **OS Agnosticism (where practical):** When creating roles or tasks intended for multiple distributions, use Ansible facts (e.g., `ansible_os_family`, `ansible_distribution`) to handle differences. If a task is highly OS-specific, make that clear in its naming or documentation.
+5.  **Security:**
+    *   Avoid hardcoding sensitive information (passwords, API keys). Use Ansible Vault for encrypting secrets or encourage users to provide them via extra vars or environment variables. For this lab setup, we might initially use plaintext placeholders in `group_vars` or inventory, but clearly mark them as needing user replacement.
+    *   Be mindful of permissions when creating files or directories.
+6.  **Variable Management:**
+    *   Default variables should be defined in `roles/your_role/defaults/main.yml`.
+    *   Group-specific variables go into `group_vars/group_name.yml`.
+    *   Host-specific variables go into `host_vars/hostname.yml` (though for this lab, we might rely more on inventory definitions).
+    *   Clearly document variables that users are expected to override.
+7.  **Testing (Conceptual):** While we might not have automated testing infrastructure initially:
+    *   Always mentally "lint" your playbooks and roles.
+    *   Test your changes against a representative VM (or multiple if OS differences are involved) before committing.
+    *   The sample playbook `playbooks/install_vim.yml` can be a simple way to verify basic connectivity and execution.
+
+### Specific Instructions:
+
+1.  **Directory Structure:** Adhere to the established directory structure:
+    *   `playbooks/`: For top-level playbooks.
+    *   `roles/`: For all roles.
+    *   `inventory/`: For inventory files.
+    *   `group_vars/`: For group-specific variables.
+    *   `host_vars/`: For host-specific variables (less common for this project initially).
+2.  **Naming Conventions:**
+    *   Playbooks: `verb_noun.yml` (e.g., `install_webserver.yml`, `configure_firewall.yml`).
+    *   Roles: `linux_distribution_service` (e.g., `common`, `nginx`, `rocky_secure_ssh`). Use generic names if applicable across OSes (e.g., `common_tools`). Role names should be lowercase and use underscores for separation (e.g., `ssh_hardening`).
+    *   Tasks within roles: Use descriptive names for tasks.
+    *   Handlers: Name handlers descriptively, often mirroring the service they affect (e.g., "Restart sshd", "Reload nginx").
+3.  **Committing Changes:**
+    *   Follow standard Git commit message conventions: a short subject line (max 50 chars), a blank line, and a more detailed body if necessary.
+    *   Reference the issue or task you are working on if applicable.
+4.  **Updating Documentation:** If you add new roles, playbooks, or significant variables that users need to be aware of, update the `README.md` accordingly.
+5.  **Handling OS Differences:**
+    *   Use `ansible_facts` like `ansible_os_family` (e.g., "RedHat", "Debian") or `ansible_distribution` (e.g., "Rocky", "Ubuntu", "AlmaLinux") in `when` conditions or to include OS-specific task files.
+    *   Example:
+        ```yaml
+        - name: Install package (RedHat family)
+          ansible.builtin.yum:
+            name: some_package
+            state: present
+          when: ansible_os_family == "RedHat"
+
+        - name: Install package (Debian family)
+          ansible.builtin.apt:
+            name: some_package
+            state: present
+          when: ansible_os_family == "Debian"
+        ```
+6.  **Sample Playbooks/Roles:**
+    *   The initial `playbooks/install_vim.yml` is a very basic example.
+    *   When adding new functionality, consider if it should be a role. Small, standalone tasks can be playbooks.
+    *   Ensure roles have a `defaults/main.yml` for all configurable variables.
+    *   Ensure roles have a `meta/main.yml` specifying dependencies or supported platforms if applicable (though not strictly enforced for all simple roles initially).
+    *   Ensure tasks that change service configurations notify an appropriate handler. Handlers should be defined in `handlers/main.yml` within the role.
+
+7.  **Role-Specific Considerations:**
+    *   **`common` role:**
+        *   When adding packages, consider if they are truly "common" or belong to a more specific role.
+        *   Ensure package lists distinguish between OS families (RedHat, Debian).
+        *   The MOTD script should be kept relatively lightweight and POSIX-compliant for broader compatibility.
+    *   **`ssh_hardening` role:**
+        *   Prioritize security. Changes should make systems more secure by default.
+        *   Clearly document the impact of variables like `ssh_port` (firewall, client changes, SELinux).
+        *   When dealing with `AllowUsers` or `AllowGroups`, ensure the logic correctly adds or removes these lines to avoid locking users out.
+        *   The `sshd -t` validation for `lineinfile` and `blockinfile` is crucial.
+
+### Before Submitting:
+
+1.  **Verify Idempotency:** Mentally review or (better) re-run your playbook/role to ensure it's idempotent.
+2.  **Check for Hardcoded Secrets:** Ensure no sensitive data is hardcoded.
+3.  **Review `README.md`:** Does it need updates based on your changes?
+4.  **Follow Plan:** Ensure all steps in your assigned plan have been completed.
+
+By following these guidelines, we can build a robust, maintainable, and useful set of Ansible scripts for our lab environment. Thank you for your contribution!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,125 @@
-# my-ansible-files
-Different ansible scripts.  Not all fully tested for errors.  Use At Your Own Risk~!
+# Ansible Lab Management
 
-A list of all my ansible scripts for many different uses.
+This repository contains Ansible scripts for managing Linux lab VMs, primarily focusing on Rocky Linux, Ubuntu, and AlmaLinux distributions.
+
+## Purpose
+
+The main goals of this repository are:
+
+1.  **Efficient Lab Management:** Provide a collection of reusable Ansible playbooks and roles to automate common administrative tasks on lab VMs.
+2.  **Learning Ansible:** Serve as a practical environment for learning and experimenting with Ansible concepts and best practices.
+3.  **Staying Current:** Keep up-to-date with emerging Ansible features and techniques.
+
+## Directory Structure
+
+*   `ansible.cfg`: Main Ansible configuration file. **Remember to update `remote_user` and `private_key_file` with your details.**
+*   `inventory/`: Contains inventory files defining hosts and groups.
+    *   `hosts.ini`: The main inventory file. **Update `ansible_user` and `ansible_ssh_private_key_file` in the `[all:vars]` section, and customize host definitions as needed.**
+*   `playbooks/`: Contains Ansible playbooks.
+    *   `install_vim.yml`: A sample playbook to install the `vim` package on all hosts.
+    *   `apply_common_configs.yml`: Applies the `common` and `ssh_hardening` roles to all targeted hosts.
+*   `roles/`: Contains Ansible roles.
+    *   `common/`: Configures common settings like timezone, essential packages, and MOTD.
+    *   `ssh_hardening/`: Applies SSH security best practices.
+*   `group_vars/`: Contains YAML files with variables for host groups.
+    *   `all.yml`: Variables that apply to all hosts. You can override defaults for the `common` and `ssh_hardening` roles here.
+*   `host_vars/`: (Directory not created by default but can be used for host-specific variables).
+
+## Core Roles and Configuration
+
+### `common` Role
+This role applies baseline configurations to all servers. Key features:
+*   Sets the system timezone (default: `Etc/UTC`).
+*   Installs a list of common utility packages (e.g., `vim`, `git`, `htop`, `ncdu`).
+*   Installs `epel-release` on RedHat family systems by default.
+*   Deploys a dynamic MOTD script to `/etc/profile.d/motd.sh`.
+
+**Key Variables (`roles/common/defaults/main.yml`, can be overridden in `group_vars/all.yml` or other group/host vars):**
+*   `common_timezone`: System timezone (e.g., "America/New_York").
+*   `common_packages_redhat`: List of packages for RedHat family OS.
+*   `common_packages_debian`: List of packages for Debian family OS.
+*   `common_install_epel_release`: Boolean, whether to install EPEL repository on RedHat systems (default: `true`).
+*   `common_motd_extra_message`: An additional custom message to display in the MOTD.
+
+### `ssh_hardening` Role
+This role enhances SSH security based on common best practices.
+*   Disables root login (`PermitRootLogin no`).
+*   Disables password authentication (`PasswordAuthentication no`), enforcing key-based auth.
+*   Allows configuration of the SSH port (default: `22`).
+    *   **Warning:** Changing the port requires firewall updates and client adjustments. The role attempts to manage SELinux rules for the new port on RedHat systems.
+*   Configures client keep-alive settings.
+*   Allows restricting SSH access via `AllowUsers` and `AllowGroups`.
+
+**Key Variables (`roles/ssh_hardening/defaults/main.yml`, can be overridden in `group_vars/all.yml` or other group/host vars):**
+*   `ssh_port`: The SSH daemon port (default: `22`).
+*   `ssh_permit_root_login`: Set to "no" to disable direct root login (default: "no").
+*   `ssh_password_authentication`: Set to "no" to disable password login (default: "no").
+*   `ssh_client_alive_interval`: Interval in seconds for client keep-alive messages.
+*   `ssh_client_alive_count_max`: Number of keep-alive messages before disconnecting.
+*   `ssh_x11_forwarding`: Whether to allow X11 forwarding (default: "no").
+*   `ssh_max_auth_tries`: Maximum authentication attempts (default: 3).
+*   `ssh_login_grace_time`: Time server waits for successful login (default: "30s").
+*   `ssh_allow_agent_forwarding`: Whether to allow SSH agent forwarding (default: "yes").
+*   `ssh_use_pam`: Whether to use PAM (default: "yes").
+*   `ssh_allow_users`: List of usernames allowed to SSH (e.g., `["user1", "user2"]`).
+*   `ssh_allow_groups`: List of group names allowed to SSH (e.g., `["ssh_users"]`).
+
+### `group_vars/all.yml`
+This file is intended for variables that should apply to all hosts in your inventory. You can override the default variables from the `common` and `ssh_hardening` roles here. For example:
+```yaml
+# group_vars/all.yml
+common_timezone: "America/Chicago"
+ssh_port: 2222
+ssh_allow_users:
+  - your_admin_user
+```
+
+## Getting Started
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository_url>
+    cd <repository_name>
+    ```
+2.  **Install Ansible:** Follow the official Ansible installation guide for your operating system: [https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+3.  **Configure SSH Access:**
+    *   Ensure you have SSH key-based authentication set up for the VMs you want to manage.
+    *   Update `ansible.cfg` with your `remote_user` and `private_key_file` path.
+    *   Alternatively, update the `[all:vars]` section in `inventory/hosts.ini` with your `ansible_user` and `ansible_ssh_private_key_file`. Settings in `inventory/hosts.ini` can override those in `ansible.cfg`.
+4.  **Customize Inventory:**
+    *   Edit `inventory/hosts.ini` to define your lab VMs and group them appropriately. Update IP addresses and hostnames.
+5.  **Run a Sample Playbook:**
+    *   To test your setup, you can run the sample `install_vim.yml` playbook or the new `apply_common_configs.yml` playbook:
+        ```bash
+        ansible-playbook playbooks/install_vim.yml
+        # OR
+        ansible-playbook playbooks/apply_common_configs.yml
+        ```
+    *   If you want to target a specific host or group, use the `-l` or `--limit` flag:
+        ```bash
+        ansible-playbook playbooks/apply_common_configs.yml -l rocky1.lab
+        ```
+    *   To run only specific roles from the `apply_common_configs.yml` playbook, use tags:
+        ```bash
+        # Apply only common configurations
+        ansible-playbook playbooks/apply_common_configs.yml --tags "common"
+
+        # Apply only SSH hardening
+        ansible-playbook playbooks/apply_common_configs.yml --tags "ssh_hardening"
+        ```
+    *   **Important:** If you use the `ssh_hardening` role and change the `ssh_port`, subsequent Ansible connections will need to know the new port. You can specify this in your inventory:
+        ```ini
+        # inventory/hosts.ini example
+        your_host ansible_host=192.168.1.X ansible_user=your_user ansible_port=2222
+        ```
+        Or by setting `ansible_port` in `group_vars` or `host_vars`.
+
+## Contributing
+
+Feel free to contribute by adding new playbooks, roles, or improving existing ones.
+
+## TODO
+
+*   Develop roles for common services (e.g., web server, database server).
+*   Create playbooks for OS-specific configurations.
+*   Implement more complex scenarios and workflows.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,12 @@
+[defaults]
+inventory = inventory/hosts.ini
+remote_user = your_ssh_user # Replace with your actual SSH username
+private_key_file = ~/.ssh/id_rsa # Replace with your actual private key path
+host_key_checking = False
+deprecation_warnings = False
+
+[privilege_escalation]
+become = True
+become_method = sudo
+become_user = root
+become_ask_pass = False

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,0 +1,47 @@
+---
+# Example group_vars/all.yml
+# These variables apply to all hosts in the inventory.
+# You can override these in more specific group_vars (e.g., group_vars/webservers.yml)
+# or host_vars (e.g., host_vars/my_server.yml).
+
+# Variables for the 'common' role
+# common_timezone: "America/New_York" # Uncomment and set to your desired timezone
+# common_install_epel_release: true # Set to false if you do not want EPEL on RedHat systems
+
+# You can customize the list of packages to be installed by the 'common' role.
+# For example, to add 'iotop' and remove 'telnet' for RedHat systems:
+# common_packages_redhat:
+#   - vim-enhanced
+#   - git
+#   - htop
+#   - ncdu
+#   - bash-completion
+#   - tree
+#   - lsof
+#   - sysstat
+#   - iotop # Added package
+
+# For Debian systems:
+# common_packages_debian:
+#   - vim
+#   - git
+#   - htop
+#   - ncdu
+#   - bash-completion
+#   - tree
+#   - lsof
+#   - sysstat
+#   - iotop # Added package
+
+# common_motd_extra_message: "This server is part of the LAB environment."
+
+# Variables for other roles can also be defined here or in their respective
+# group_vars files.
+
+# Example for a hypothetical 'ssh_hardening' role (to be created)
+# ssh_port: 2222
+# ssh_permit_root_login: "no"
+# ssh_password_authentication: "no"
+# ssh_allow_users:
+#   - user1
+#   - user2

--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -1,0 +1,15 @@
+[webservers]
+web1.example.com
+web2.example.com
+
+[dbservers]
+db1.example.com
+
+[labvms]
+rocky1.lab ansible_host=192.168.1.10
+ubuntu1.lab ansible_host=192.168.1.11
+alma1.lab ansible_host=192.168.1.12
+
+[all:vars]
+ansible_user=your_ssh_user # Replace with your actual SSH username
+ansible_ssh_private_key_file=~/.ssh/id_rsa # Replace with your actual private key path

--- a/playbooks/apply_common_configs.yml
+++ b/playbooks/apply_common_configs.yml
@@ -1,0 +1,47 @@
+---
+- name: Apply common configurations and SSH hardening
+  hosts: all
+  become: yes
+  gather_facts: yes # Good practice to ensure facts are available for roles
+
+  roles:
+    - role: common
+      tags: common
+    - role: ssh_hardening
+      tags: ssh_hardening
+
+  # Example of how to override role variables at the playbook level:
+  # vars:
+  #   common_timezone: "America/Los_Angeles"
+  #   ssh_port: 22022
+  #   ssh_allow_users:
+  #     - your_user
+  #   # Ensure your user is in this list if you are testing ssh_allow_users
+  #   # and you are not connecting as root (which should be disabled by the role).
+
+  # Pre-tasks and Post-tasks can be added here if needed
+  # pre_tasks:
+  #   - name: Ensure sudo is installed (Debian family)
+  #     ansible.builtin.apt:
+  #       name: sudo
+  #       state: present
+  #     when: ansible_os_family == "Debian"
+
+  # post_tasks:
+  #   - name: Final system reboot if required by any role (use with caution)
+  #     ansible.builtin.reboot:
+  #     when: some_reboot_condition_is_met | default(false)
+
+# To run this playbook:
+# ansible-playbook playbooks/apply_common_configs.yml
+
+# To run only specific parts (tags):
+# ansible-playbook playbooks/apply_common_configs.yml --tags "common"
+# ansible-playbook playbooks/apply_common_configs.yml --tags "ssh_hardening"
+
+# Remember to update your inventory file (inventory/hosts.ini)
+# and ansible.cfg (or group_vars/all.yml) with your SSH user and private key.
+# If you change the SSH port via ssh_hardening role, you'll need to update your
+# Ansible inventory or use `ansible_port` for subsequent connections.
+# Example in inventory:
+# your_host ansible_host=your_ip_address ansible_port=22022 ansible_user=your_user

--- a/playbooks/install_vim.yml
+++ b/playbooks/install_vim.yml
@@ -1,0 +1,9 @@
+---
+- name: Install vim
+  hosts: all
+  become: yes
+  tasks:
+    - name: Install vim
+      ansible.builtin.package:
+        name: vim
+        state: present

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+# defaults file for roles/common
+
+common_timezone: "Etc/UTC"
+
+# Default common packages for RedHat family systems
+common_packages_redhat:
+  - vim-enhanced
+  - git
+  - htop
+  - ncdu
+  - bash-completion
+  - tree
+  - telnet # Useful for network troubleshooting
+  - lsof
+  - sysstat # for iostat, mpstat, etc.
+
+# Default common packages for Debian family systems
+common_packages_debian:
+  - vim
+  - git
+  - htop
+  - ncdu
+  - bash-completion
+  - tree
+  - telnet # Useful for network troubleshooting
+  - lsof
+  - sysstat # for iostat, mpstat, etc.
+
+# Whether to install EPEL repository on RedHat family systems.
+# Set to true if you need packages from EPEL.
+common_install_epel_release: true
+
+# Extra message to display in the MOTD
+common_motd_extra_message: "For assistance, contact the IT department."

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# tasks file for roles/common
+
+- name: Set timezone
+  ansible.builtin.timezone:
+    name: "{{ common_timezone }}"
+  notify: Reload systemd daemon if timezone changed # Handler needed for this
+
+- name: Install common packages (RedHat family)
+  ansible.builtin.yum:
+    name: "{{ common_packages_redhat }}"
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Install common packages (Debian family)
+  ansible.builtin.apt:
+    name: "{{ common_packages_debian }}"
+    state: present
+    update_cache: yes
+  when: ansible_os_family == "Debian"
+
+- name: Install EPEL repository for RedHat family (if specified)
+  ansible.builtin.yum:
+    name: epel-release
+    state: present
+  when:
+    - ansible_os_family == "RedHat"
+    - common_install_epel_release | bool
+  tags:
+    - packages
+    - epel
+
+- name: Template MOTD script
+  ansible.builtin.template:
+    src: motd.sh.j2
+    dest: /etc/profile.d/motd.sh
+    mode: '0755'
+
+# Placeholder for a handler that might be needed for timezone changes
+# This would typically go in a roles/common/handlers/main.yml file
+# - name: Reload systemd daemon if timezone changed
+#   ansible.builtin.systemd:
+#     daemon_reload: yes
+#   listen: "Reload systemd daemon if timezone changed"

--- a/roles/common/tasks/motd.sh.j2
+++ b/roles/common/tasks/motd.sh.j2
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# Custom MOTD script
+#
+
+# Get distribution information
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    OS_NAME=$PRETTY_NAME
+elif type lsb_release >/dev/null 2>&1; then
+    OS_NAME=$(lsb_release -si)
+elif [ -f /etc/lsb-release ]; then
+    . /etc/lsb-release
+    OS_NAME=$DISTRIB_ID
+elif [ -f /etc/debian_version ]; then
+    OS_NAME="Debian $(cat /etc/debian_version)"
+elif [ -f /etc/redhat-release ]; then
+    OS_NAME=$(cat /etc/redhat-release)
+else
+    OS_NAME=$(uname -s)
+fi
+
+# Get kernel version
+KERNEL_VERSION=$(uname -r)
+
+# Get system load
+LOAD_AVERAGE=$(uptime | awk -F'load average:' '{ print $2 }' | sed 's/^[ \t]*//;s/[ \t]*$//')
+
+# Get memory usage
+MEMORY_USAGE=$(free -m | awk 'NR==2{printf "%.2f%% (%s/%s MB)", $3*100/$2, $3, $2 }')
+
+# Get disk usage for /
+DISK_USAGE_ROOT=$(df -h / | awk 'NR==2{printf "%s (%s used / %s total)", $5, $3, $2}')
+
+# Get current logged in users
+LOGGED_IN_USERS=$(users | wc -w)
+WHO_USERS=$(who | awk '{print $1}' | sort -u | tr '\n' ' ')
+
+# Get IP Address (excluding loopback, preferring global scope)
+IP_ADDRESS=$(ip -4 addr show | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v '127.0.0.1' | head -n 1)
+if [ -z "$IP_ADDRESS" ]; then
+    IP_ADDRESS=$(ip -4 addr show | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1) # Fallback if no non-loopback
+fi
+
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+WHITE='\033[0;37m'
+NC='\033[0m' # No Color
+
+echo -e ""
+echo -e "${GREEN}Welcome to $(hostname -f)${NC}"
+echo -e ""
+echo -e "${YELLOW}System Information:${NC}"
+echo -e "  ${CYAN}OS Distribution:${NC} ${OS_NAME}"
+echo -e "  ${CYAN}Kernel Version:${NC}  ${KERNEL_VERSION}"
+echo -e "  ${CYAN}Hostname:${NC}        $(hostname -s)"
+echo -e "  ${CYAN}FQDN:${NC}            $(hostname -f)"
+echo -e "  ${CYAN}IP Address:${NC}      ${IP_ADDRESS:-N/A}"
+echo -e ""
+echo -e "${YELLOW}Resource Usage:${NC}"
+echo -e "  ${CYAN}CPU Load:${NC}        ${LOAD_AVERAGE}"
+echo -e "  ${CYAN}Memory Usage:${NC}    ${MEMORY_USAGE}"
+echo -e "  ${CYAN}Root Filesystem:${NC} ${DISK_USAGE_ROOT}"
+echo -e ""
+echo -e "${YELLOW}Users & Time:${NC}"
+echo -e "  ${CYAN}Current Users:${NC}   ${LOGGED_IN_USERS} (${WHO_USERS})"
+echo -e "  ${CYAN}System Time:${NC}     $(date)"
+echo -e "  ${CYAN}Uptime:${NC}          $(uptime -p | sed 's/up //')"
+echo -e ""
+echo -e "${PURPLE}This system is managed by Ansible.${NC}"
+
+if [ -n "{{ common_motd_extra_message }}" ]; then
+  echo -e ""
+  echo -e "${PURPLE}{{ common_motd_extra_message }}${NC}"
+fi
+echo -e ""

--- a/roles/ssh_hardening/defaults/main.yml
+++ b/roles/ssh_hardening/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+# defaults file for roles/ssh_hardening
+
+ssh_port: 22
+ssh_permit_root_login: "no"
+ssh_password_authentication: "no" # Enforces key-based authentication
+
+# ClientAliveInterval: seconds before server sends null packet to keep connection alive
+# ClientAliveCountMax: number of client alive messages before disconnecting client
+# Total timeout = ClientAliveInterval * ClientAliveCountMax
+ssh_client_alive_interval: 300 # 5 minutes
+ssh_client_alive_count_max: 3  # Results in 15 minutes timeout for idle sessions
+
+ssh_x11_forwarding: "no" # Disable X11 forwarding unless specifically needed
+ssh_max_auth_tries: 3    # Limit the number of authentication attempts per connection
+ssh_login_grace_time: "30s" # Time server waits for successful login before disconnecting
+ssh_allow_agent_forwarding: "yes" # Can be a security risk in some environments; set to "no" if not needed
+ssh_use_pam: "yes" # Recommended to be yes, especially on systems using PAM
+
+# Define lists of users or groups allowed to SSH.
+# If both are empty, it's typically assumed all users are allowed (depending on sshd_config defaults).
+# If either is non-empty, only users/groups in these lists will be allowed.
+ssh_allow_users: []
+# Example:
+# ssh_allow_users:
+#   - admin_user
+#   - another_user
+
+ssh_allow_groups: []
+# Example:
+# ssh_allow_groups:
+#   - sshusers
+#   - administrators
+
+# Warning: Changing the SSH port will require firewall adjustments
+# and client configuration updates (e.g., ssh -p {{ ssh_port }} user@host).
+# This role does not manage firewall rules by default.
+# Also, ensure the new port is allowed by SELinux if enabled on the system.
+# The role attempts to handle SELinux for RedHat family if port is changed.

--- a/roles/ssh_hardening/handlers/main.yml
+++ b/roles/ssh_hardening/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# handlers file for roles/ssh_hardening
+
+- name: Restart sshd
+  ansible.builtin.service:
+    name: "{{ ssh_service_name }}"
+    state: restarted
+  vars:
+    ssh_service_name: "{{ 'sshd' if ansible_os_family == 'RedHat' or ansible_distribution == 'AlmaLinux' or ansible_distribution == 'Rocky' else 'ssh' }}"

--- a/roles/ssh_hardening/tasks/main.yml
+++ b/roles/ssh_hardening/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+# tasks file for roles/ssh_hardening
+
+- name: Harden SSH configuration
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    state: present
+    validate: 'sshd -t -f %s'
+  loop:
+    - { regexp: '^#?PermitRootLogin', line: 'PermitRootLogin {{ ssh_permit_root_login }}' }
+    - { regexp: '^#?PasswordAuthentication', line: 'PasswordAuthentication {{ ssh_password_authentication }}' }
+    - { regexp: '^#?Port', line: 'Port {{ ssh_port }}' }
+    - { regexp: '^#?ClientAliveInterval', line: 'ClientAliveInterval {{ ssh_client_alive_interval }}' }
+    - { regexp: '^#?ClientAliveCountMax', line: 'ClientAliveCountMax {{ ssh_client_alive_count_max }}' }
+    - { regexp: '^#?X11Forwarding', line: 'X11Forwarding {{ ssh_x11_forwarding }}' }
+    - { regexp: '^#?MaxAuthTries', line: 'MaxAuthTries {{ ssh_max_auth_tries }}' }
+    - { regexp: '^#?LoginGraceTime', line: 'LoginGraceTime {{ ssh_login_grace_time }}' }
+    - { regexp: '^#?AllowAgentForwarding', line: 'AllowAgentForwarding {{ ssh_allow_agent_forwarding }}' }
+    - { regexp: '^#?PermitEmptyPasswords', line: 'PermitEmptyPasswords no' } # Should always be no
+    - { regexp: '^#?ChallengeResponseAuthentication', line: 'ChallengeResponseAuthentication no' } # Usually for PAM, disable if not needed
+    - { regexp: '^#?UsePAM', line: 'UsePAM {{ ssh_use_pam }}' }
+  notify: Restart sshd
+  tags:
+    - ssh
+    - security
+
+- name: Ensure AllowUsers or AllowGroups is configured if specified
+  ansible.builtin.blockinfile:
+    path: /etc/ssh/sshd_config
+    block: |
+      {% if ssh_allow_users | length > 0 %}
+      AllowUsers {{ ssh_allow_users | join(' ') }}
+      {% endif %}
+      {% if ssh_allow_groups | length > 0 %}
+      AllowGroups {{ ssh_allow_groups | join(' ') }}
+      {% endif %}
+    marker: "# {mark} ANSIBLE MANAGED BLOCK FOR ALLOWUSERS/ALLOWGROUPS"
+    validate: 'sshd -t -f %s'
+  when: (ssh_allow_users | length > 0) or (ssh_allow_groups | length > 0)
+  notify: Restart sshd
+  tags:
+    - ssh
+    - security
+
+- name: Remove existing AllowUsers or AllowGroups if variables are empty
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: "^(AllowUsers|AllowGroups).*"
+    state: absent
+  when: (ssh_allow_users | length == 0) and (ssh_allow_groups | length == 0)
+  notify: Restart sshd
+  tags:
+    - ssh
+    - security
+
+# Note: Changing the SSH port will require firewall adjustments and
+# client configuration updates (e.g., ssh -p {{ ssh_port }} user@host).
+# This role does not manage firewall rules by default.
+
+# SELinux considerations for non-standard port (RedHat family)
+- name: Allow new SSH port in SELinux (if applicable and port changed)
+  ansible.builtin.command: "semanage port -a -t ssh_port_t -p tcp {{ ssh_port }}"
+  when:
+    - ansible_selinux.status == "enabled"
+    - ssh_port != 22
+    - ansible_os_family == "RedHat"
+  changed_when: true # semanage port returns 0 if already set, but we want to notify handler
+  notify: Restart sshd
+  ignore_errors: "{{ ansible_check_mode }}" # Might fail if semanage not installed, but -t should catch config errors
+  tags:
+    - ssh
+    - security
+    - selinux
+
+# Handlers will be defined in roles/ssh_hardening/handlers/main.yml
+# ---
+# - name: Restart sshd
+#   ansible.builtin.service:
+#     name: sshd # or ssh on Debian/Ubuntu
+#     state: restarted


### PR DESCRIPTION
This commit introduces two foundational roles:

1.  **`common` role:**
    *   Sets timezone.
    *   Installs common packages (configurable for RedHat/Debian families).
    *   Installs EPEL release by default on RedHat family.
    *   Deploys a dynamic MOTD script.
    *   Default variables are in `roles/common/defaults/main.yml`.

2.  **`ssh_hardening` role:**
    *   Hardens SSH configuration based on best practices (e.g., disables root login, password authentication).
    *   Allows configuration of SSH port, client keep-alive, user/group access restrictions.
    *   Includes SELinux handling for non-standard ports on RedHat family.
    *   Default variables are in `roles/ssh_hardening/defaults/main.yml`.

Also includes:
- `group_vars/all.yml` with examples for overriding role defaults.
- `playbooks/apply_common_configs.yml` to apply both roles.
- Updated `README.md` with documentation for new roles and playbook.
- Updated `AGENTS.md` with new conventions and role-specific instructions.